### PR TITLE
print ETA, refactor library callback, fix download to use base_path

### DIFF
--- a/src/banner.rs
+++ b/src/banner.rs
@@ -1,3 +1,19 @@
+/// Prints the banner using a FIGlet font.
+///
+/// This function loads the ASCII art font from an external resource file (slant.flf)
+/// using `include_str!`, and creates a FIGlet font instance with `FIGfont::from_content`.
+/// It then converts the text "Project Epoch" into ASCII art and prints it to the console.
+/// Additionally, the function prints a tagline indicating that this is an unofficial patch download
+/// utility by Sogladev, along with a URL for reporting bugs or issues. Lastly, it prints a line
+/// of dashes as a visual separator.
+///
+/// # Panics
+///
+/// This function will panic if:
+/// - The font data cannot be loaded from the specified resource file.
+/// - The FIGlet font cannot be created or the conversion of the text to ASCII art fails.
+///
+/// Therefore, it is assumed that the required font resource exists and is correctly formatted.
 use figlet_rs::FIGfont;
 
 pub fn print_banner() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::process;
 
-use rs_manifest_patcher::{banner, prompt};
+use rs_manifest_patcher::{banner, prompt, Progress};
 use rs_manifest_patcher::{Config, Manifest, Transaction};
 
 #[tokio::main]
@@ -33,7 +33,11 @@ async fn run(config: Config) -> Result<(), Box<dyn Error>> {
     }
 
     if transaction.has_pending_operations() {
-        transaction.download().await?;
+        let progress_handler = |progress: &Progress| {
+            progress.print();
+            Ok(())
+        };
+        transaction.download(progress_handler).await?;
     }
 
     println!("\n{}", "-".repeat(100));

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -8,6 +8,11 @@ use url::Url;
 #[derive(Debug, Clone)]
 pub enum Location {
     Url(Url),
+    /// Wraps a [std::path::PathBuf] representing a file system path.
+    ///
+    /// This field stores an independently owned and mutable file system path.
+    /// It leverages the platform-specific features of [std::path::PathBuf]
+    /// to provide a reliable method for handling file paths regardless of the operating system.
     FilePath(PathBuf),
 }
 
@@ -39,6 +44,15 @@ impl Location {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+/// Represents a patch file with its associated metadata.
+///
+/// # Fields
+///
+/// * `path` - A string containing the file path where the patch file is located.
+/// * `hash` - A string representing the checksum or hash of the file, used for integrity verification.
+/// * `size` - A 64-bit integer indicating the file size in bytes.
+/// * `custom` - A boolean flag that indicates if the patch file is custom.
+/// * `url` - A string holding the URL related to the patch file. This field is serialized using the name "URL".
 pub struct PatchFile {
     pub path: String,
     pub hash: String,
@@ -50,6 +64,14 @@ pub struct PatchFile {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+/// Represents a manifest configuration that includes version information
+/// and a collection of patch files.
+///
+/// # Fields
+///
+/// - `version`: A String representing the manifest's version.
+/// - `files`: A vector of `PatchFile` items, each corresponding to a file that is
+///   subject to patching.
 pub struct Manifest {
     pub version: String,
     pub files: Vec<PatchFile>,

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,21 +1,24 @@
-use std::io::Write;
+// use std::io::Write;
 use std::time::Duration;
 
 use humansize::{format_size, DECIMAL};
 
-const MAX_FILENAME_LENGTH: usize = 25;
+const MAX_FILENAME_LENGTH: usize = 20;
 const PROGRESS_BAR_WIDTH: usize = 20;
-const TOTAL_LINE_WIDTH: usize = 80;
 
+#[derive(serde::Serialize)]
 pub struct Progress {
     pub current: u64,
-    pub total: u64,
     pub file_index: usize,
     pub total_files: usize,
     pub speed: f64,
     pub file_size: u64,
     pub elapsed: Duration,
     pub filename: String,
+    pub total_size_downloaded: u64,
+    pub total_amount_left: u64,
+    pub expected_time_left: f64,
+    pub total_download_size: i64,
 }
 
 impl Progress {
@@ -38,28 +41,31 @@ impl Progress {
     }
 
     pub fn print(&self) {
-        let percent = (self.current as f64 / self.total as f64) * 100.0;
-        let progress_bar = Self::create_progress_bar(self.current, self.total);
+        let percent = (self.current as f64 / self.file_size as f64) * 100.0;
+        let progress_bar = Self::create_progress_bar(self.current, self.file_size);
         let filename = Self::truncate_filename(&self.filename);
         let speed = format_size(self.speed as u64, DECIMAL);
         let size = format_size(self.file_size, DECIMAL);
         let total_files_width = self.total_files.to_string().len();
+        let total_left = format_size(self.total_amount_left, DECIMAL);
 
-        if self.current >= self.total {
-            print!("\r{:width$}", "", width = TOTAL_LINE_WIDTH); // Clear the line
+        if self.current >= self.file_size {
+            print!("\r\x1B[2K"); // Clear the line
             println!(
-                "\r[{:>width$}/{}] {:<filename_width$} {} 100% (complete) {}         ",
+                "\r[{:>width$}/{}] {:<filename_width$} {} 100% (complete) | {} | Left: {} | ETA: {:.1}s",
                 self.file_index,
                 self.total_files,
                 filename,
                 progress_bar,
                 size,
+                total_left,
+                self.expected_time_left,
                 width = total_files_width,
                 filename_width = MAX_FILENAME_LENGTH - 1
             );
         } else {
             print!(
-                "\r[{:>width$}/{}] {:<filename_width$} {} {:5.1}% {:<8}/s {}",
+                "\r[{:>width$}/{}] {:<filename_width$} {} {:5.1}% | {:<8}/s | {} | Left: {} | ETA: {:.1}s",
                 self.file_index,
                 self.total_files,
                 filename,
@@ -67,10 +73,12 @@ impl Progress {
                 percent,
                 speed,
                 size,
+                total_left,
+                self.expected_time_left,
                 width = total_files_width,
                 filename_width = MAX_FILENAME_LENGTH - 1
             );
-            std::io::stdout().flush().unwrap(); // Ensure the output is flushed immediately
+            // std::io::stdout().flush().unwrap(); // Ensure the output is flushed immediately
         }
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -7,17 +7,29 @@ const MAX_FILENAME_LENGTH: usize = 20;
 const PROGRESS_BAR_WIDTH: usize = 20;
 
 #[derive(serde::Serialize)]
+/// Represents the progress information for a file download or processing task.
 pub struct Progress {
+    /// The number of bytes processed for the current file.
     pub current: u64,
+    /// The index of the current file being processed.
     pub file_index: usize,
+    /// The total number of files to be processed.
     pub total_files: usize,
+    /// The current processing speed in bytes per second.
     pub speed: f64,
+    /// The total size of the current file in bytes.
     pub file_size: u64,
+    /// The duration elapsed since the processing of the current file started.
     pub elapsed: Duration,
+    /// The name of the current file.
     pub filename: String,
+    /// The cumulative size of data downloaded across all files.
     pub total_size_downloaded: u64,
+    /// The total amount of data remaining to be downloaded in bytes.
     pub total_amount_left: u64,
+    /// The estimated time (in seconds) remaining to complete the download.
     pub expected_time_left: f64,
+    /// The total download size of all files combined in bytes.
     pub total_download_size: i64,
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -224,8 +224,8 @@ impl Transaction {
     pub async fn download(&self) -> Result<(), Box<dyn Error>> {
         let http_client = reqwest::Client::new();
         for (idx, op) in self.pending().iter().enumerate() {
-            let dest_path = std::path::Path::new(&op.patch_file.path);
             // Create parent directories if they don't exist
+            let dest_path = self.base_path.join(&op.patch_file.path);
             if let Some(dir) = dest_path.parent() {
                 tokio::fs::create_dir_all(dir).await?;
             }
@@ -241,7 +241,7 @@ impl Transaction {
             }
 
             let total_size = response.content_length().unwrap_or(0);
-            let mut file = tokio::fs::File::create(dest_path).await?;
+            let mut file = tokio::fs::File::create(dest_path.clone()).await?;
             let start = std::time::Instant::now();
             let mut downloaded: u64 = 0;
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -228,14 +228,14 @@ impl Transaction {
             "Total download size must be non-negative, but found {}.",
             total
         );
-        return total;
+        total
     }
 
     fn disk_space_change(&self) -> i64 {
         self.operations
             .iter()
             .filter(|x| x.status != Status::Present)
-            .map(|x| x.patch_file.size - x.size as i64)
+            .map(|x| x.patch_file.size - x.size)
             .sum()
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -18,6 +18,15 @@ pub enum Status {
 }
 
 #[derive(Clone)]
+/// Represents a transaction operation involving file patching.
+///
+/// This struct holds the details for an operation that patches a file, including the patch file data,
+/// the size of the file patch, and the current status of the operation.
+///
+/// # Fields
+/// - `patch_file`: The patch file associated with the operation.
+/// - `size`: The size of the patch, represented as a 64-bit signed integer.
+/// - `status`: The status of the file operation.
 pub struct FileOperation {
     pub patch_file: PatchFile,
     pub size: i64,


### PR DESCRIPTION
`[1/6] A.bin                [--------------------] 100% (complete) | 1.05 MB | Left: 7.29 MB | ETA: 7.6s`

Add ETA,
fix print clean line

refactor library to use a callback

[fix: download also to base_path](https://github.com/sogladev/rs_manifest_patcher/commit/d3bf1726f3ccdd0d35c10ea570c42d71ff82c15f)

[print extra fields, send Progress to callback](https://github.com/sogladev/rs_manifest_patcher/commit/ecf8958d167e34dbaba4bb285b1aebe4136fc59f) 

[docs: generate docs](https://github.com/sogladev/rs_manifest_patcher/commit/9add0e9931ad62bec2b59f58d248eaefcdfe3047)
